### PR TITLE
handle hidden and hiddenBefore/After nodes correctly

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -692,12 +692,9 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 
 		$mustNotConstraints = [];
 
-		if (!$this->contextNode->getContext()->isInaccessibleContentShown()) {
+		if (!$this->contextNode->getContext()->isInvisibleContentShown()) {
 			// Filter out all hidden elements
 			$mustNotConstraints[] =	[ 'term' => ['_hidden' => true]];
-		}
-
-		if (!$this->contextNode->getContext()->isInvisibleContentShown()) {
 			// if now < hiddenBeforeDateTime: HIDE
 			// -> hiddenBeforeDateTime > now
 			$mustNotConstraints[] =	[ 'range' => [ '_hiddenBeforeDateTime' => [ 'gt' => 'now' ] ] ];

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -693,7 +693,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 		if (!$this->contextNode->getContext()->isInvisibleContentShown()) {
 			$this->request['query']['filtered']['filter']['bool']['must_not'] = [
 				// Filter out all hidden elements
-				[ 'term' => ['_hidden' => true]],
+				[ 'term' => [ '_hidden' => true ] ],
 				// if now < hiddenBeforeDateTime: HIDE
 				// -> hiddenBeforeDateTime > now
 				[ 'range' => [ '_hiddenBeforeDateTime' => [ 'gt' => 'now' ] ] ],

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -690,18 +690,16 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 
 		$this->contextNode = $contextNode;
 
-		$mustNotConstraints = [];
-
 		if (!$this->contextNode->getContext()->isInvisibleContentShown()) {
-			// Filter out all hidden elements
-			$mustNotConstraints[] =	[ 'term' => ['_hidden' => true]];
-			// if now < hiddenBeforeDateTime: HIDE
-			// -> hiddenBeforeDateTime > now
-			$mustNotConstraints[] =	[ 'range' => [ '_hiddenBeforeDateTime' => [ 'gt' => 'now' ] ] ];
-			$mustNotConstraints[] = [ 'range' => [ '_hiddenAfterDateTime' => [ 'lt' => 'now' ] ] ];
+			$this->request['query']['filtered']['filter']['bool']['must_not'] = [
+				// Filter out all hidden elements
+				[ 'term' => ['_hidden' => true]],
+				// if now < hiddenBeforeDateTime: HIDE
+				// -> hiddenBeforeDateTime > now
+				[ 'range' => [ '_hiddenBeforeDateTime' => [ 'gt' => 'now' ] ] ],
+				[ 'range' => [ '_hiddenAfterDateTime' => [ 'lt' => 'now' ] ] ],
+			];
 		}
-
-		$this->request['query']['filtered']['filter']['bool']['must_not'] = $mustNotConstraints;
 
 		return $this;
 	}

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -110,24 +110,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 					'bool' => array(
 						'must' => array(),
 						'should' => array(),
-						'must_not' => array(
-							// Filter out all hidden elements
-							array(
-								'term' => array('_hidden' => TRUE)
-							),
-							// if now < hiddenBeforeDateTime: HIDE
-							// -> hiddenBeforeDateTime > now
-							array(
-								'range' => array('_hiddenBeforeDateTime' => array(
-									'gt' => 'now'
-								))
-							),
-							array(
-								'range' => array('_hiddenAfterDateTime' => array(
-									'lt' => 'now'
-								))
-							),
-						),
+						'must_not' => array(),
 					)
 				)
 			)
@@ -706,6 +689,22 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 		}
 
 		$this->contextNode = $contextNode;
+
+		$mustNotConstraints = [];
+
+		if (!$this->contextNode->getContext()->isInaccessibleContentShown()) {
+			// Filter out all hidden elements
+			$mustNotConstraints[] =	[ 'term' => ['_hidden' => true]];
+		}
+
+		if (!$this->contextNode->getContext()->isInvisibleContentShown()) {
+			// if now < hiddenBeforeDateTime: HIDE
+			// -> hiddenBeforeDateTime > now
+			$mustNotConstraints[] =	[ 'range' => [ '_hiddenBeforeDateTime' => [ 'gt' => 'now' ] ] ];
+			$mustNotConstraints[] = [ 'range' => [ '_hiddenAfterDateTime' => [ 'lt' => 'now' ] ] ];
+		}
+
+		$this->request['query']['filtered']['filter']['bool']['must_not'] = $mustNotConstraints;
 
 		return $this;
 	}


### PR DESCRIPTION
Set the Elasticsearch must_not criteria according to $context->isInvisibleContentShown() setting.
### Test

http://dev.daz-neos.boot2docker:8080/neos/service/nodes?searchTerm=Stanton&workspaceName=user-admin&contextNode=%2Fsites%2Fdazsite%40user-admin&nodeTypes%5B%5D=CRON.DazSite%3ANewsDocumentMixin&nodeTypes%5B%5D=CRON.DazSite%3AArticle
### Run Unit-Tests

```
[www@7e54cda7b7e0 : ~/typo3-app]$ bin/phpunit -c Build/BuildEssentials/PhpUnit/UnitTests.xml Packages/Application/Flowpack.ElasticSearch.ContentRepositoryAdaptor/Tests/Unit/Eel/
PHPUnit 4.6.10 by Sebastian Bergmann and contributors.

Configuration read from /data/www/typo3-app/Build/BuildEssentials/PhpUnit/UnitTests.xml

....................

Time: 60 ms, Memory: 6.50Mb

OK (20 tests, 20 assertions)
```
