### PR TITLE
Use the node identifier instead of the node path

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -110,6 +110,16 @@ class NodeIndexer extends AbstractNodeIndexer {
 	}
 
 	/**
+	 * Something like getContextPath() but using the Node Identifier instead of the Path
+	 *
+	 * @param NodeInterface $node
+	 * @return string
+	 */
+	private function getContextIdentifier(NodeInterface $node) {
+		return $node->getIdentifier() . $node->getWorkspace()->getName();
+	}
+
+	/**
 	 * index this node, and add it to the current bulk request.
 	 *
 	 * @param NodeInterface $node
@@ -121,7 +131,7 @@ class NodeIndexer extends AbstractNodeIndexer {
 
 		if ($this->isIndexingEnabled($node) === false) return;
 
-		$contextPath = $node->getContextPath();
+		$contextIdentifier = $this->getContextIdentifier($node);
 
 		if ($this->settings['indexAllWorkspaces'] === FALSE) {
 			// we are only supposed to index the live workspace.
@@ -138,24 +148,24 @@ class NodeIndexer extends AbstractNodeIndexer {
 
 
 		if ($targetWorkspaceName !== NULL) {
-			$contextPath = str_replace($node->getContext()->getWorkspace()->getName(), $targetWorkspaceName, $contextPath);
+			$contextIdentifier = str_replace($node->getContext()->getWorkspace()->getName(), $targetWorkspaceName, $contextIdentifier);
 		}
 
-		$contextPathHash = sha1($contextPath);
+		$contextIdentifierHash = sha1($contextIdentifier);
 		$nodeType = $node->getNodeType();
 
 		$mappingType = $this->getIndex()->findType(NodeTypeMappingBuilder::convertNodeTypeNameToMappingName($nodeType));
 
-		// Remove document with the same contextPathHash but different NodeType, required after NodeType change
+		// Remove document with the same contextIdentifierHash but different NodeType, required after NodeType change
 		$this->logger->log(sprintf('NodeIndexer: Removing node %s from index (if node type changed from %s). ID: %s',
-			$contextPath, $node->getNodeType()->getName(), $contextPathHash), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
+			$contextIdentifier, $node->getNodeType()->getName(), $contextIdentifierHash), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
 
 		$this->getIndex()->request('DELETE', '/_query', array(), json_encode([
 			'query' => [
 				'bool' => [
 					'must' => [
 						'ids' => [
-							'values' => [ $contextPathHash ]
+							'values' => [ $contextIdentifierHash ]
 						]
 					],
 					'must_not' => [
@@ -169,21 +179,21 @@ class NodeIndexer extends AbstractNodeIndexer {
 
 		if ($node->isRemoved()) {
 			// TODO: handle deletion from the fulltext index as well
-			$mappingType->deleteDocumentById($contextPathHash);
-			$this->logger->log(sprintf('NodeIndexer: Removed node %s from index (node flagged as removed). ID: %s', $contextPath, $contextPathHash), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
+			$mappingType->deleteDocumentById($contextIdentifierHash);
+			$this->logger->log(sprintf('NodeIndexer: Removed %s from index (node flagged as removed). ID: %s', $node, $contextIdentifierHash), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
 
 			return;
 		}
 
 		$logger = $this->logger;
 		$fulltextIndexOfNode = array();
-		$nodePropertiesToBeStoredInIndex = $this->extractPropertiesAndFulltext($node, $fulltextIndexOfNode, function($propertyName) use ($logger, $contextPathHash) {
-			$logger->log(sprintf('NodeIndexer (%s) - Property "%s" not indexed because no configuration found.', $contextPathHash, $propertyName), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
+		$nodePropertiesToBeStoredInIndex = $this->extractPropertiesAndFulltext($node, $fulltextIndexOfNode, function($propertyName) use ($logger, $contextIdentifierHash) {
+			$logger->log(sprintf('NodeIndexer (%s) - Property "%s" not indexed because no configuration found.', $contextIdentifierHash, $propertyName), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
 		});
 
 		$document = new ElasticSearchDocument($mappingType,
 			$nodePropertiesToBeStoredInIndex,
-			$contextPathHash
+			$contextIdentifierHash
 		);
 
 		$documentData = $document->getData();
@@ -243,7 +253,7 @@ class NodeIndexer extends AbstractNodeIndexer {
 		}
 
 		$this->logger->log(sprintf('NodeIndexer: Added / updated node [%s] %s. ID: %s',
-			$nodeType->getName(), $contextPath, $contextPathHash), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
+			$nodeType->getName(), $contextIdentifier, $contextIdentifierHash), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
 	}
 
 	/**
@@ -269,14 +279,14 @@ class NodeIndexer extends AbstractNodeIndexer {
 			}
 		}
 
-		$closestFulltextNodeContextPath = str_replace($closestFulltextNode->getContext()->getWorkspace()->getName(), 'live', $closestFulltextNode->getContextPath());
-		$closestFulltextNodeContextPathHash = sha1($closestFulltextNodeContextPath);
+		$closestFulltextNodeContextIdentifier = str_replace($closestFulltextNode->getContext()->getWorkspace()->getName(), 'live', $this->getContextIdentifier($closestFulltextNode));
+		$closestFulltextNodeContextIdentifierHash = sha1($closestFulltextNodeContextIdentifier);
 
 		$this->currentBulkRequest[] = array(
 			array(
 				'update' => array(
 					'_type' => NodeTypeMappingBuilder::convertNodeTypeNameToMappingName($closestFulltextNode->getNodeType()->getName()),
-					'_id' => $closestFulltextNodeContextPathHash
+					'_id' => $closestFulltextNodeContextIdentifierHash
 				)
 			),
 			// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html
@@ -356,7 +366,7 @@ class NodeIndexer extends AbstractNodeIndexer {
 		}
 
 		// TODO: handle deletion from the fulltext index as well
-		$identifier = sha1($node->getContextPath());
+		$identifier = sha1($this->getContextIdentifier($node));
 
 		$this->currentBulkRequest[] = array(
 			array(
@@ -367,7 +377,7 @@ class NodeIndexer extends AbstractNodeIndexer {
 			)
 		);
 
-		$this->logger->log(sprintf('NodeIndexer: Removed node %s from index (node actually removed). Persistence ID: %s', $node->getContextPath(), $identifier), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
+		$this->logger->log(sprintf('NodeIndexer: Removed %s from index (node actually removed). Persistence ID: %s', $node, $identifier), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
 	}
 
 	/**

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -116,7 +116,9 @@ class NodeIndexer extends AbstractNodeIndexer {
 	 * @return string
 	 */
 	protected function getContextIdentifier(NodeInterface $node) {
-		return $node->getIdentifier() . '-' . $node->getWorkspace()->getName();
+		$contextPath = $node->getContextPath();
+
+		return $node->getIdentifier() . substr($contextPath, strpos($contextPath, '@'));
 	}
 
 	/**

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -366,18 +366,16 @@ class NodeIndexer extends AbstractNodeIndexer {
 		}
 
 		// TODO: handle deletion from the fulltext index as well
-		$identifier = $this->getContextIdentifier($node);
-
 		$this->currentBulkRequest[] = array(
 			array(
 				'delete' => array(
 					'_type' => NodeTypeMappingBuilder::convertNodeTypeNameToMappingName($node->getNodeType()),
-					'_id' => $identifier
+					'_id' => $this->getContextIdentifier($node),
 				)
 			)
 		);
 
-		$this->logger->log(sprintf('NodeIndexer: Removed %s from index (node actually removed). Persistence ID: %s', $node, $identifier), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
+		$this->logger->log(sprintf('NodeIndexer: Removed %s from index (node actually removed).', $node), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
 	}
 
 	/**


### PR DESCRIPTION
Use the node identifier instead of the node path

Using the node path for identifying the node in ES causes some issues while moving the node to another path. This commit changes this behavior, generating an unique ES identifier for the record using the node identifier instead of using the node path.
