### PR TITLE
DAVDAZ-716 improve highlighting / testing [WIP]

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -635,7 +635,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 		));
 
 		// We automatically enable result highlighting when doing fulltext searches. It is up to the user to use this information or not use it.
-		return $this->highlight(150, 2);
+		return $this->highlight(300, 2);
 	}
 
 	/**
@@ -657,7 +657,10 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 					'__fulltext*' => array(
 						'fragment_size' => $fragmentSize,
 						'no_match_size' => $fragmentSize,
-						'number_of_fragments' => $fragmentCount
+						'number_of_fragments' => $fragmentCount,
+						'boundary_max_scan' => 50,
+						'fragment_offset' => 50,
+						'boundary_chars' => '.!?:'
 					)
 				)
 			);

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -110,30 +110,37 @@
             'h1':
               type: string
               include_in_all: true
+              term_vector: 'with_positions_offsets'
               boost: 20
             'h2':
               type: string
               include_in_all: true
+              term_vector: 'with_positions_offsets'
               boost: 12
             'h3':
               type: string
               include_in_all: true
+              term_vector: 'with_positions_offsets'
               boost: 10
             'h4':
               type: string
               include_in_all: true
+              term_vector: 'with_positions_offsets'
               boost: 5
             'h5':
               type: string
               include_in_all: true
+              term_vector: 'with_positions_offsets'
               boost: 3
             'h6':
               type: string
               include_in_all: true
+              term_vector: 'with_positions_offsets'
               boost: 2
             'text':
               type: string
               include_in_all: true
+              term_vector: 'with_positions_offsets'
               boost: 1
 
 'TYPO3.Neos.NodeTypes:Text':


### PR DESCRIPTION
### Goal

The standard highlighting of the ES adapter is pretty limited and cannot be configured. For better presentation of search results the highlighter should be changeable to the ES offered ones (**highlighter (plain / default), fast-vector-highlighter, postings-highlighter**). Also the settings for the chosen highlighter have to be configurable in the query DSL (**ElasticSearchQueryBuilder.php**).

Please refer to https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-request-highlighting.html

Note: For fast-vector-highlighter and postings-highlighter the indexing configuration has to be changed and re-indexing is required. This can than be done in the project's site package.
