### PR TITLE
Make the highlighting configurable

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -126,6 +126,11 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      */
     protected $result = array();
 
+    /**
+     * @Flow\InjectConfiguration(package="TYPO3.TYPO3CR.Search")
+     * @var array
+     */
+    protected $settings = array();
 
     /**
      * HIGH-LEVEL API
@@ -662,11 +667,24 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
         ));
 
         // We automatically enable result highlighting when doing fulltext searches. It is up to the user to use this information or not use it.
-        return $this->highlight(150, 2);
+        return $this->addHighlight();
     }
 
     /**
-     * Configure Result Highlighting. Only makes sense in combination with fulltext(). By default, highlighting is enabled.
+     * Adds default highlighting setup for fulltext
+     *
+     */
+    private function addHighlight()
+    {
+        $this->request['highlight'] = $this->settings['defaultHightlightSettings'];
+
+        return $this;
+    }
+
+    /**
+     * Configure Result Highlighting for __fulltext* field.
+     *
+     * By default, highlighting is enabled and uses the TYPO3.TYPO3CR.Search.defaultHightlightSettings setting.
      * It can be disabled by calling "highlight(FALSE)".
      *
      * @param integer|boolean $fragmentSize The result fragment size for highlight snippets. If this parameter is FALSE, highlighting will be disabled.

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -127,7 +127,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
     protected $result = array();
 
     /**
-     * @Flow\InjectConfiguration(package="TYPO3.TYPO3CR.Search")
+     * @Flow\InjectConfiguration(package="Flowpack.ElasticSearch.ContentRepositoryAdaptor")
      * @var array
      */
     protected $settings = array();

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -27,6 +27,40 @@ TYPO3:
             ansiConsoleBackend:
               disableAnsi: false
 
+      # If you want to use "Fast vector highlighter" and its possibilities make sure you add term_vector in the
+      # __fulltext index.
+      # see https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-request-highlighting.html#fast-vector-highlighter
+      #
+      # i.e.:
+      # 'TYPO3.Neos:Document':
+      #    properties:
+      #      __fulltext:
+      #        search:
+      #          elasticSearchMapping:
+      #            properties:
+      #              # enable term vector for improved highlighting
+      #              text:
+      #                term_vector: 'with_positions_offsets'
+      #              h1:
+      #                term_vector: 'with_positions_offsets'
+      #              h2:
+      #                term_vector: 'with_positions_offsets'
+      #              h3:
+      #                term_vector: 'with_positions_offsets'
+      #              h4:
+      #                term_vector: 'with_positions_offsets'
+      #              h5:
+      #                term_vector: 'with_positions_offsets'
+      #              h6:
+      #                term_vector: 'with_positions_offsets'
+      defaultHightlightSettings:
+        fields:
+          # backwards compatible setup:
+          __fulltext*:
+            fragment_size: 150
+            no_match_size: 150
+            number_of_fragments: 2
+
       defaultConfigurationPerType:
 
         string:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -27,40 +27,6 @@ TYPO3:
             ansiConsoleBackend:
               disableAnsi: false
 
-      # If you want to use "Fast vector highlighter" and its possibilities make sure you add term_vector in the
-      # __fulltext index.
-      # see https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-request-highlighting.html#fast-vector-highlighter
-      #
-      # i.e.:
-      # 'TYPO3.Neos:Document':
-      #    properties:
-      #      __fulltext:
-      #        search:
-      #          elasticSearchMapping:
-      #            properties:
-      #              # enable term vector for improved highlighting
-      #              text:
-      #                term_vector: 'with_positions_offsets'
-      #              h1:
-      #                term_vector: 'with_positions_offsets'
-      #              h2:
-      #                term_vector: 'with_positions_offsets'
-      #              h3:
-      #                term_vector: 'with_positions_offsets'
-      #              h4:
-      #                term_vector: 'with_positions_offsets'
-      #              h5:
-      #                term_vector: 'with_positions_offsets'
-      #              h6:
-      #                term_vector: 'with_positions_offsets'
-      defaultHightlightSettings:
-        fields:
-          # backwards compatible setup:
-          __fulltext*:
-            fragment_size: 150
-            no_match_size: 150
-            number_of_fragments: 2
-
       defaultConfigurationPerType:
 
         string:
@@ -101,3 +67,43 @@ TYPO3:
           elasticSearchMapping:
             type: string
             index: not_analyzed
+
+Flowpack:
+  ElasticSearch:
+    ContentRepositoryAdaptor:
+
+      # Configure the highlight feature
+      #
+      # If you want to use "Fast vector highlighter" and its possibilities make sure you add term_vector in the
+      # __fulltext index.
+      # see https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-request-highlighting.html#fast-vector-highlighter
+      #
+      # i.e.:
+      # 'TYPO3.Neos:Document':
+      #    properties:
+      #      __fulltext:
+      #        search:
+      #          elasticSearchMapping:
+      #            properties:
+      #              # enable term vector for improved highlighting
+      #              text:
+      #                term_vector: 'with_positions_offsets'
+      #              h1:
+      #                term_vector: 'with_positions_offsets'
+      #              h2:
+      #                term_vector: 'with_positions_offsets'
+      #              h3:
+      #                term_vector: 'with_positions_offsets'
+      #              h4:
+      #                term_vector: 'with_positions_offsets'
+      #              h5:
+      #                term_vector: 'with_positions_offsets'
+      #              h6:
+      #                term_vector: 'with_positions_offsets'
+      defaultHightlightSettings:
+        fields:
+          # backwards compatible setup:
+          __fulltext*:
+            fragment_size: 150
+            no_match_size: 150
+            number_of_fragments: 2


### PR DESCRIPTION
Allow setting up custom highlighting schemes, as documented here:
https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-request-highlighting.html

Keeps the "public function highlight()" as it was before, as it was public and @api.

See also https://github.com/cron-eu/daz-neos-base/pull/552 for an usage of this new possibility.
