### PR TITLE
Use the node identifier instead of the node path

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -118,9 +118,9 @@ class NodeIndexer extends AbstractNodeIndexer
      * @param NodeInterface $node
      * @return string
      */
-    private function getContextIdentifier(NodeInterface $node)
+    protected function getContextIdentifier(NodeInterface $node)
     {
-        return $node->getIdentifier() . $node->getWorkspace()->getName();
+        return $node->getIdentifier() . '-' . $node->getWorkspace()->getName();
     }
 
     /**
@@ -157,21 +157,20 @@ class NodeIndexer extends AbstractNodeIndexer
             $contextIdentifier = str_replace($node->getContext()->getWorkspace()->getName(), $targetWorkspaceName, $contextIdentifier);
         }
 
-        $contextIdentifierHash = sha1($contextIdentifier);
         $nodeType = $node->getNodeType();
 
         $mappingType = $this->getIndex()->findType(NodeTypeMappingBuilder::convertNodeTypeNameToMappingName($nodeType));
 
         // Remove document with the same contextIdentifierHash but different NodeType, required after NodeType change
-        $this->logger->log(sprintf('NodeIndexer: Removing node %s from index (if node type changed from %s). ID: %s',
-            $contextIdentifier, $node->getNodeType()->getName(), $contextIdentifierHash), LOG_DEBUG, null, 'ElasticSearch (CR)');
+        $this->logger->log(sprintf('NodeIndexer: Removing %s from index (if node type changed from %s). ID: %s',
+            $contextIdentifier, $node->getNodeType()->getName(), $node), LOG_DEBUG, null, 'ElasticSearch (CR)');
 
         $this->getIndex()->request('DELETE', '/_query', array(), json_encode([
             'query' => [
                 'bool' => [
                     'must' => [
                         'ids' => [
-                            'values' => [ $contextIdentifierHash ]
+                            'values' => [ $contextIdentifier ]
                         ]
                     ],
                     'must_not' => [
@@ -185,21 +184,21 @@ class NodeIndexer extends AbstractNodeIndexer
 
         if ($node->isRemoved()) {
             // TODO: handle deletion from the fulltext index as well
-            $mappingType->deleteDocumentById($contextIdentifierHash);
-            $this->logger->log(sprintf('NodeIndexer: Removed %s from index (node flagged as removed). ID: %s', $node, $contextIdentifierHash), LOG_DEBUG, null, 'ElasticSearch (CR)');
+            $mappingType->deleteDocumentById($contextIdentifier);
+            $this->logger->log(sprintf('NodeIndexer: Removed %s from index (node flagged as removed). ID: %s', $node, $contextIdentifier), LOG_DEBUG, null, 'ElasticSearch (CR)');
 
             return;
         }
 
         $logger = $this->logger;
         $fulltextIndexOfNode = array();
-        $nodePropertiesToBeStoredInIndex = $this->extractPropertiesAndFulltext($node, $fulltextIndexOfNode, function ($propertyName) use ($logger, $contextIdentifierHash) {
-            $logger->log(sprintf('NodeIndexer (%s) - Property "%s" not indexed because no configuration found.', $contextIdentifierHash, $propertyName), LOG_DEBUG, null, 'ElasticSearch (CR)');
+        $nodePropertiesToBeStoredInIndex = $this->extractPropertiesAndFulltext($node, $fulltextIndexOfNode, function ($propertyName) use ($logger, $contextIdentifier) {
+            $logger->log(sprintf('NodeIndexer (%s) - Property "%s" not indexed because no configuration found.', $contextIdentifier, $propertyName), LOG_DEBUG, null, 'ElasticSearch (CR)');
         });
 
         $document = new ElasticSearchDocument($mappingType,
             $nodePropertiesToBeStoredInIndex,
-            $contextIdentifierHash
+            $contextIdentifier
         );
 
         $documentData = $document->getData();
@@ -259,7 +258,7 @@ class NodeIndexer extends AbstractNodeIndexer
         }
 
         $this->logger->log(sprintf('NodeIndexer: Added / updated node [%s] %s. ID: %s',
-            $nodeType->getName(), $contextIdentifier, $contextIdentifierHash), LOG_DEBUG, null, 'ElasticSearch (CR)');
+            $nodeType->getName(), $contextIdentifier, $contextIdentifier), LOG_DEBUG, null, 'ElasticSearch (CR)');
     }
 
     /**
@@ -287,13 +286,12 @@ class NodeIndexer extends AbstractNodeIndexer
         }
 
         $closestFulltextNodeContextIdentifier = str_replace($closestFulltextNode->getContext()->getWorkspace()->getName(), 'live', $this->getContextIdentifier($closestFulltextNode));
-        $closestFulltextNodeContextIdentifierHash = sha1($closestFulltextNodeContextIdentifier);
 
         $this->currentBulkRequest[] = array(
             array(
                 'update' => array(
                     '_type' => NodeTypeMappingBuilder::convertNodeTypeNameToMappingName($closestFulltextNode->getNodeType()->getName()),
-                    '_id' => $closestFulltextNodeContextIdentifierHash
+                    '_id' => $closestFulltextNodeContextIdentifier
                 )
             ),
             // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html
@@ -376,7 +374,7 @@ class NodeIndexer extends AbstractNodeIndexer
         }
 
         // TODO: handle deletion from the fulltext index as well
-        $identifier = sha1($this->getContextIdentifier($node));
+        $identifier = $this->getContextIdentifier($node);
 
         $this->currentBulkRequest[] = array(
             array(

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -376,18 +376,16 @@ class NodeIndexer extends AbstractNodeIndexer
         }
 
         // TODO: handle deletion from the fulltext index as well
-        $identifier = $this->getContextIdentifier($node);
-
         $this->currentBulkRequest[] = array(
             array(
                 'delete' => array(
                     '_type' => NodeTypeMappingBuilder::convertNodeTypeNameToMappingName($node->getNodeType()),
-                    '_id' => $identifier
+                    '_id' => $this->getContextIdentifier($node),
                 )
             )
         );
 
-        $this->logger->log(sprintf('NodeIndexer: Removed %s from index (node actually removed). Persistence ID: %s', $node, $identifier), LOG_DEBUG, null, 'ElasticSearch (CR)');
+        $this->logger->log(sprintf('NodeIndexer: Removed %s from index (node actually removed).', $node), LOG_DEBUG, null, 'ElasticSearch (CR)');
     }
 
     /**

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -120,7 +120,9 @@ class NodeIndexer extends AbstractNodeIndexer
      */
     protected function getContextIdentifier(NodeInterface $node)
     {
-        return $node->getIdentifier() . '-' . $node->getWorkspace()->getName();
+        $contextPath = $node->getContextPath();
+
+        return $node->getIdentifier() . substr($contextPath, strpos($contextPath, '@'));
     }
 
     /**

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -115,14 +115,30 @@ class NodeIndexer extends AbstractNodeIndexer
     /**
      * Something like getContextPath() but using the Node Identifier instead of the Path
      *
+     * Result is a string like <identifier>@<workspace>;<dimensionsList>.
+     * @see NodeInterface::getContextPath()
+     *
      * @param NodeInterface $node
      * @return string
      */
     protected function getContextIdentifier(NodeInterface $node)
     {
-        $contextPath = $node->getContextPath();
+        $contextIdentifier = $node->getIdentifier();
 
-        return $node->getIdentifier() . substr($contextPath, strpos($contextPath, '@'));
+        $context = $node->getContext();
+
+        $workspaceName = $context->getWorkspace()->getName();
+        $contextIdentifier .= '@' . $workspaceName;
+
+        if ($context->getDimensions() !== array()) {
+            $contextIdentifier .= ';';
+            foreach ($context->getDimensions() as $dimensionName => $dimensionValues) {
+                $contextIdentifier .= $dimensionName . '=' . implode(',', $dimensionValues) . '&';
+            }
+            $contextIdentifier = substr($contextIdentifier, 0, -1);
+        }
+
+        return $contextIdentifier;
     }
 
     /**


### PR DESCRIPTION
Use the node identifier instead of the node path as the _id.

Using the node path for identifying the node in ES causes some issues while moving the node to another path. This commit changes this behavior, generating an unique ES identifier for the record using the node identifier instead of using the node path.

Rebased to PSR-2 from #5.
